### PR TITLE
Removed get_sidebar(); call in `single-content.php`

### DIFF
--- a/wp-content/themes/borderzine/partials/content-single.php
+++ b/wp-content/themes/borderzine/partials/content-single.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * The template for displaying content in the single.php template
+ */
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'hnews item' ); ?> itemscope itemtype="https://schema.org/Article">
+
+	<?php do_action('largo_before_post_header'); ?>
+
+	<header>
+
+		<?php largo_maybe_top_term(); ?>
+
+		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
+		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
+			<h2 class="subtitle"><?php echo $subtitle ?></h2>
+		<?php endif; ?>
+		<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
+
+		<?php if ( ! of_get_option( 'single_social_icons' ) == false ) {
+			largo_post_social_links();
+		} ?>
+
+<?php largo_post_metadata( $post->ID ); ?>
+
+	</header><!-- / entry header -->
+
+	<?php
+		do_action('largo_after_post_header');
+
+		largo_hero(null,'span12');
+
+		do_action('largo_after_hero');
+	?>
+
+	<section class="entry-content clearfix" itemprop="articleBody">
+		
+		<?php largo_entry_content( $post ); ?>
+		
+	</section>
+
+	<?php do_action('largo_after_post_content'); ?>
+
+</article>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Copied `single-content.php` to `boderzine` child theme and removed the `get_sidebar();` call since we don't want a sidebar on single post pages.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #5

## Testing/Questions

Features that this PR affects:

- Single post sidebar

Steps to test this PR:

1. Set the default post template to `One Column` layout
2. Verify no sidebars appear on posts