### PR TITLE
Copy content.php template, remove categories and increase image size

### DIFF
--- a/wp-content/themes/borderzine/partials/content.php
+++ b/wp-content/themes/borderzine/partials/content.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * The default template for displaying content
+ *
+ * @package Largo
+ */
+$args = array (
+	// post-specific, should probably not be filtered but may be useful
+	'post_id' => $post->ID,
+	'hero_class' => largo_hero_class( $post->ID, FALSE ),
+
+	// only used to determine the existence of a youtube_url
+	'values' => get_post_custom( $post->ID ),
+
+	// this should be filtered in the event of a term-specific archive
+	'featured' => has_term( 'homepage-featured', 'prominence' ),
+
+	// $show_thumbnail does not control whether or not the thumbnail is displayed;
+	// it controls whether or not the thumbnail is displayed normally.
+	'show_thumbnail' => TRUE,
+	'show_byline' => TRUE,
+	'show_excerpt' => TRUE,
+	'in_series' => FALSE,
+);
+
+$args = apply_filters( 'largo_content_partial_arguments', $args, get_queried_object() );
+
+extract( $args );
+
+$entry_classes = 'entry-content';
+
+$show_top_tag = largo_has_categories_or_tags();
+
+if ( $featured ) {
+	$entry_classes .= ' span10 with-hero';
+	$show_thumbnail = FALSE;
+}
+
+?>
+<article id="post-<?php the_ID(); ?>" <?php post_class('clearfix'); ?>>
+
+	<?php
+		// Special treatment for posts that are in the Homepage Featured prominence taxonomy term and have thumbnails
+		if ( $featured && ( has_post_thumbnail() || $values['youtube_url'] ) ) { ?>
+			<header>
+				<div class="hero span12 <?php echo $hero_class; ?>">
+				<?php
+					if( has_post_thumbnail() ){
+						echo( '<a href="' . get_permalink() . '" title="' . the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ', 'echo' => false )) . '" rel="bookmark">' );
+						the_post_thumbnail( 'full' );
+						echo( '</a>' );
+					}
+				?>
+				</div>
+			</header>
+		<?php } // end Homepage Featured thumbnail block
+
+		echo '<div class="' . $entry_classes . '">';
+
+		if ( $show_thumbnail ) {
+			echo '<div class="has-thumbnail '.$hero_class.'"><a href="' . get_permalink() . '">' . get_the_post_thumbnail( get_the_ID(), 'medium' ) . '</a></div>';
+		}
+	?>
+
+		<h2 class="entry-title">
+			<a href="<?php the_permalink(); ?>" title="<?php the_title_attribute( array( 'before' => __( 'Permalink to', 'largo' ) . ' ' ) )?>" rel="bookmark"><?php the_title(); ?></a>
+		</h2>
+
+		<?php
+			if ( $show_byline ) { ?>
+				<h5 class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></h5>
+			<?php }
+		?>
+
+		<?php
+			if ( $show_excerpt ) {
+				largo_excerpt();
+			}
+		?>
+
+		</div><!-- .entry-content -->
+
+</article><!-- #post-<?php the_ID(); ?> -->


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Copied `content.php` template from Largo into Borderzine child theme
- Removed post categories
- Increased post thumbnail image size to medium

Before:
![screencapture-borderzine-flywheelsites-series-borderlands-project-2019-09-20-12_32_19](https://user-images.githubusercontent.com/18353636/65343343-bb980d80-dba2-11e9-96ce-a37c1ea8ee09.png)

After (ignore the missing top image):
![screencapture-borderzine-test-series-borderlands-project-2019-09-20-12_33_09](https://user-images.githubusercontent.com/18353636/65343372-d66a8200-dba2-11e9-9769-ca7c566b27bd.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #16

## Testing/Questions

Features that this PR affects:

- Category and series landing pages

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is `medium` an ok size for the images?

Steps to test this PR:

1. View a category or series landing page