### PR TITLE
Switch article top byline back to largo_byline default

### DIFF
--- a/wp-content/themes/borderzine/partials/content-single.php
+++ b/wp-content/themes/borderzine/partials/content-single.php
@@ -16,7 +16,7 @@
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
 			<h2 class="subtitle"><?php echo $subtitle ?></h2>
 		<?php endif; ?>
-        <div class="byline"><?php borderzine_byline( true, false, get_the_ID() ); ?></div>
+        <div class="byline"><?php largo_byline( true, false, get_the_ID() ); ?></div>
 
 		<?php if ( ! of_get_option( 'single_social_icons' ) == false ) {
 			largo_post_social_links();


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Switches the top byline on articles back to `largo_byline` from the new custom `borderzine_byline` class

<img width="1282" alt="Screen Shot 2019-09-20 at 2 03 39 PM" src="https://user-images.githubusercontent.com/18353636/65348643-aa093280-dbaf-11e9-82ad-b1e718eeece5.png">

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For https://github.com/INN/umbrella-borderzine/issues/3#issuecomment-533652282

## Testing/Questions

Features that this PR affects:

- Article bylines

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Does it look ok now?