### PR TITLE
Use `display_name` for author bio widget

### DIFF
--- a/wp-content/themes/borderzine/partials/author-bio-social-links.php
+++ b/wp-content/themes/borderzine/partials/author-bio-social-links.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Social links for the author described in $author_object
+ *
+ * @param WP_User $author_object the author
+ * @since 0.5.3
+ */
+$email = $author_obj->user_email;
+
+/*
+ * Figure out whether to hide the author's email address
+ */
+$user_meta = get_user_meta($author_obj->ID);
+
+$show_email = 'off';
+if (isset($user_meta['show_email'][0])) {
+	$show_email = $user_meta['show_email'][0];
+} else if ( !empty($author_obj->show_email) ) {
+	$show_email = $author_obj->show_email;
+}
+
+?>
+<ul class="social-links">
+	<?php if ( $fb = $author_obj->fb ) { ?>
+		<li class="facebook">
+			<a href="https://facebook.com/<?php echo largo_fb_url_to_username(esc_url( $fb )); ?>" title="<?php echo esc_attr( $author_obj->display_name ); ?> on Facebook" rel="me"><i class="icon-facebook"></i></a>
+		</li>
+	<?php } ?>
+
+	<?php if ( $twitter = $author_obj->twitter ) { ?>
+		<li class="twitter">
+			<a href="https://twitter.com/<?php echo largo_twitter_url_to_username ( $twitter ); ?>"><i class="icon-twitter"></i></a>
+		</li>
+	<?php } ?>
+
+	<?php if ( $email && $show_email !== 'off' ) { ?>
+		<li class="email">
+			<a class="email" href="mailto:<?php echo esc_attr( $email ); ?>" title="e-mail <?php echo esc_attr( $author_obj->display_name ); ?>"><i class="icon-mail"></i></a>
+		</li>
+	<?php } ?>
+
+	<?php if ( $linkedin = $author_obj->linkedin ) { ?>
+		<li class="linkedin">
+			<a href="<?php echo esc_url( $linkedin ); ?>" title="<?php echo esc_attr( $author_obj->display_name ); ?> on LinkedIn"><i class="icon-linkedin"></i></a>
+		</li>
+	<?php } ?>
+
+	<?php
+		if ( !is_author() ) {
+			printf( __( '<li class="author-posts-link"><a class="url" href="%1$s" rel="author" title="See all posts by %2$s">More by %2$s</a></li>', 'largo' ),
+				get_author_posts_url( $author_obj->ID, $author_obj->user_nicename ),
+				!empty( $author_obj->display_name ) ? esc_attr( $author_obj->display_name ) : __("this author", 'largo')
+			);
+		}
+	?>
+</ul>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Copies `author-bio-social-links.php` partial and swaps out `$author_obj->first_name` for `$author_obj->display_name` so the entire author name is displayed.

Before:
![Screen Shot 2019-09-24 at 3 38 33 PM](https://user-images.githubusercontent.com/18353636/65544524-62e9ad00-dee1-11e9-8047-381a622fe372.png)

After:
![Screen Shot 2019-09-24 at 3 38 25 PM](https://user-images.githubusercontent.com/18353636/65544523-62e9ad00-dee1-11e9-8740-c3554372fef1.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #26

## Testing/Questions

Features that this PR affects:

- Author Bio widget

Steps to test this PR:

1. View the author bio widget and make sure the first and last names of the author are displayed.