### PR TITLE
Swap out userphoto_..._thumbnail function for userphoto_...photo

### DIFF
--- a/wp-content/themes/borderzine/functions.php
+++ b/wp-content/themes/borderzine/functions.php
@@ -92,7 +92,7 @@ function borderzine_has_avatar( $email ) {
 		if ( ! empty ( $result ) ) {
 			return true;
 		// this checks if the user has a photo placed by the User Photo plugin
-		} else if( function_exists( userphoto_the_author_thumbnail() ) ){
+		} else if( function_exists( userphoto_the_author_photo() ) ){
 			return true;
 		} else {
 			if ( largo_has_gravatar( $email ) ) {


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Swapped out `userphoto_the_author_thumbnail()` for `userphoto_the_author_photo()` in `borderzine_has_avatar` function.

This should solve the image appearing small issue.

Before:
![Screen Shot 2019-09-26 at 4 40 05 PM](https://user-images.githubusercontent.com/18353636/65723473-77ae7800-e07c-11e9-90f2-cf2b02700bc5.png)

After:
![Screen Shot 2019-09-26 at 4 39 53 PM](https://user-images.githubusercontent.com/18353636/65723472-77ae7800-e07c-11e9-8768-9b37c63c74df.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #21 

## Testing/Questions

Features that this PR affects:

- Author images

Steps to test this PR:

1. View where author images are displayed in posts and verify that they aren't super small anymore.