### PR TITLE
Add single-column template for series landing pages

### DIFF
--- a/wp-content/themes/borderzine/Gruntfile.js
+++ b/wp-content/themes/borderzine/Gruntfile.js
@@ -10,6 +10,7 @@ module.exports = function(grunt) {
     
     var CSS_LESS_FILES = {
         'css/style.css': 'less/style.less',
+        'css/series-landing-one-column.css': 'less/series-landing-one-column.less',
         'homepages/assets/css/homepage.css': 'homepages/assets/less/homepage.less',
     };
 

--- a/wp-content/themes/borderzine/css/series-landing-one-column.css
+++ b/wp-content/themes/borderzine/css/series-landing-one-column.css
@@ -1,0 +1,4 @@
+.span12:first-of-type {
+  margin-left: 0;
+}
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImxlc3Mvc2VyaWVzLWxhbmRpbmctb25lLWNvbHVtbi5sZXNzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVBLE9BQU87RUFDTCxjQUFBIiwic291cmNlc0NvbnRlbnQiOlsiQGltcG9ydCAocmVmZXJlbmNlKSBcIi4vdmFyaWFibGVzLmxlc3NcIjtcblxuLnNwYW4xMjpmaXJzdC1vZi10eXBle1xuICBtYXJnaW4tbGVmdDogMDtcbn1cbiJdfQ== */

--- a/wp-content/themes/borderzine/css/series-landing-one-column.min.css
+++ b/wp-content/themes/borderzine/css/series-landing-one-column.min.css
@@ -1,0 +1,1 @@
+.span12:first-of-type{margin-left:0}

--- a/wp-content/themes/borderzine/less/series-landing-one-column.less
+++ b/wp-content/themes/borderzine/less/series-landing-one-column.less
@@ -1,0 +1,5 @@
+@import (reference) "./variables.less";
+
+.span12:first-of-type{
+  margin-left: 0;
+}

--- a/wp-content/themes/borderzine/series-landing-one-column.php
+++ b/wp-content/themes/borderzine/series-landing-one-column.php
@@ -41,13 +41,13 @@ $content_span = array( 'one-column' => 12, 'two-column' => 8, 'three-column' => 
 ?>
 
 <?php if ( $opt['header_enabled'] ) : ?>
+	<?php
+		/**
+		 * Use Largo's gutenberg alignfull styles to make a fullwidth hero image
+		 */
+		largo_hero( $post, 'alignfull' );
+	?>
 	<section id="series-header" class="span12 clearfix">
-		<?php
-			/**
-			 * Use Largo's gutenberg alignfull styles to make a fullwidth hero image
-			 */
-			largo_hero( $post, 'alignfull' );
-		?>
 		<h1 class="entry-title"><?php the_title(); ?></h1>
 		<?php
 		if ( $opt['show_series_byline'] )

--- a/wp-content/themes/borderzine/series-landing-one-column.php
+++ b/wp-content/themes/borderzine/series-landing-one-column.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Template Name: Single-column Series Landing Page
+ * Description: A series landing page without the central loop of posts, and without sidebars as such.
+ */
+get_header();
+
+// Load up our meta data and whatnot
+the_post();
+
+//make sure it's a landing page.
+if ( 'cftl-tax-landing' == $post->post_type ) {
+	$opt = get_post_custom( $post->ID );
+	foreach( $opt as $key => $val ) {
+		$opt[ $key ] = $val[0];
+	}
+	$opt['show'] = maybe_unserialize($opt['show']);	//make this friendlier
+	if ( 'all' == $opt['per_page'] ) $opt['per_page'] = -1;
+	/**
+	 * $opt will look like this:
+	 *
+	 *	Array (
+	 *		[header_enabled] => boolean
+	 *		[show_series_byline] => boolean
+	 *		[show_sharebar] => boolean
+	 *		[header_style] => standard|alternate
+	 *		[cftl_layout] => one-column|two-column|three-column
+	 *		[per_page] => integer|all
+	 *		[post_order] => ASC|DESC|top, DESC|top, ASC
+	 *		[footer_enabled] => boolean
+	 *		[footerhtml] => {html}
+	 *		[show] => array with boolean values for keys byline|excerpt|image|tags
+	 *	)
+	 *
+	 * The post description is stored in 'excerpt' and the custom HTML header is the post content
+	 */
+}
+
+// #content span width helper
+$content_span = array( 'one-column' => 12, 'two-column' => 8, 'three-column' => 5 );
+?>
+
+<?php if ( $opt['header_enabled'] ) : ?>
+	<section id="series-header" class="span12 clearfix">
+		<h1 class="entry-title"><?php the_title(); ?></h1>
+		<?php
+		if ( $opt['show_series_byline'] )
+			echo '<h5 class="byline">' . largo_byline( false, false, get_the_ID() ) . '</h5>';
+		if ( $opt['show_sharebar'] )
+			largo_post_social_links();
+		?>
+		<div class="description">
+			<?php echo apply_filters( 'the_content', $post->post_excerpt ); ?>
+		</div>
+		<?php
+		if ( 'standard' == $opt['header_style'] ) {
+			//need to set a size, make this responsive, etc
+			?>
+			<div class="full series-banner full-image"><?php the_post_thumbnail( 'full' ); ?></div>
+		<?php
+		} else {
+			the_content();
+		}
+		?>
+	</section>
+<?php endif; ?>
+
+
+<?php // display left rail
+if ( 'three-column' == $opt['cftl_layout'] ) :
+		$left_rail = $opt['left_region'];
+?>
+	<aside id="sidebar-left" class="span12 clearfix">
+		<div class="widget-area" role="complementary">
+			<?php
+				dynamic_sidebar($left_rail);
+			?>
+		</div>
+	</aside>
+<?php
+endif;
+?>
+
+<?php // display left rail
+if ($opt['cftl_layout'] != 'one-column') :
+	if (!empty($opt['right_region']) && $opt['right_region'] !== 'none') {
+		$right_rail = $opt['right_region'];
+	} else {
+		$right_rail = 'single';
+	}
+	?>
+	<aside id="sidebar" class="span12 clearfix">
+		<?php do_action('largo_before_sidebar_content'); ?>
+		<div class="widget-area" role="complementary">
+			<?php
+				do_action('largo_before_sidebar_widgets');
+				dynamic_sidebar($right_rail);
+				do_action('largo_after_sidebar_widgets');
+			?>
+		</div><!-- .widget-area -->
+		<?php do_action('largo_after_sidebar_content'); ?>
+	</aside>
+
+	<?php
+endif;
+
+//display series footer
+if ( 'none' != $opt['footer_style'] ) : ?>
+	<section id="series-footer">
+		<?php
+			/*
+			 * custom footer html
+			 * If we don't reset the post meta here, then the footer HTML is from the wrong post. This doesn't mess with LMP, because it happens after LMP is enqueued in the main column.
+			 */
+			wp_reset_postdata();
+			if ( 'custom' == $opt['footer_style']) {
+				echo apply_filters( 'the_content', $opt['footerhtml'] );
+			} else if ( 'widget' == $opt['footer_style'] && is_active_sidebar( $post->post_name . "_footer" ) ) { ?>
+				<aside id="sidebar-bottom" class="clearfix span12">
+					<?php dynamic_sidebar( $post->post_name . "_footer" ); ?>
+				</aside>
+			<?php }
+		?>
+	</section>
+<?php endif; ?>
+
+<!-- /.grid_4 -->
+<?php get_footer();

--- a/wp-content/themes/borderzine/series-landing-one-column.php
+++ b/wp-content/themes/borderzine/series-landing-one-column.php
@@ -41,6 +41,12 @@ $content_span = array( 'one-column' => 12, 'two-column' => 8, 'three-column' => 
 ?>
 
 <?php if ( $opt['header_enabled'] ) : ?>
+	<?php
+		/**
+		 * Use Largo's gutenberg alignfull styles to make a fullwidth hero image
+		 */
+		largo_hero( $post, 'alignfull' );
+	?>
 	<section id="series-header" class="span12 clearfix">
 		<h1 class="entry-title"><?php the_title(); ?></h1>
 		<?php

--- a/wp-content/themes/borderzine/series-landing-one-column.php
+++ b/wp-content/themes/borderzine/series-landing-one-column.php
@@ -3,6 +3,20 @@
  * Template Name: Single-column Series Landing Page
  * Description: A series landing page without the central loop of posts, and without sidebars as such.
  */
+
+// enqueue the specific stylesheet
+add_action( 'wp_enqueue_scripts', function() {
+	$suffix = (LARGO_DEBUG) ? '.min' : '';
+
+	wp_enqueue_style(
+		'series-landing-one-column',
+		get_stylesheet_directory_uri() . '/css/series-landing-one-column' . $suffix . '.css',
+		array(),
+		filemtime( get_stylesheet_directory() . '/css/series-landing-one-column' . $suffix . '.css' )
+	);
+});
+
+// start the page
 get_header();
 
 // Load up our meta data and whatnot

--- a/wp-content/themes/borderzine/series-landing-one-column.php
+++ b/wp-content/themes/borderzine/series-landing-one-column.php
@@ -41,13 +41,13 @@ $content_span = array( 'one-column' => 12, 'two-column' => 8, 'three-column' => 
 ?>
 
 <?php if ( $opt['header_enabled'] ) : ?>
-	<?php
-		/**
-		 * Use Largo's gutenberg alignfull styles to make a fullwidth hero image
-		 */
-		largo_hero( $post, 'alignfull' );
-	?>
 	<section id="series-header" class="span12 clearfix">
+		<?php
+			/**
+			 * Use Largo's gutenberg alignfull styles to make a fullwidth hero image
+			 */
+			largo_hero( $post, 'alignfull' );
+		?>
 		<h1 class="entry-title"><?php the_title(); ?></h1>
 		<?php
 		if ( $opt['show_series_byline'] )


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a template for the series landing page without the main post list, and where all template sidebars are full width.
- Adds stylesheet for same

![Screen Shot 2019-09-30 at 18 27 21 ](https://user-images.githubusercontent.com/1754187/65921332-f6265500-e3af-11e9-9503-e60105674e30.png)


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For the landing-page portion of #44. Custom HTML for the custom-HTML-widget portions of the layout will be developed separately.

## Testing/Questions

Features that this PR affects:

- 

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] 

Steps to test this PR:

1. Create a series landing page
2. Choose the "Single-column Series Landing Page" template from the list of possible templates
3. Other option choices:
    - Layout style: alternate
    - Custom HTML for the header: 
        ```
        <p><img class="alignleft wp-image-35676 size-thumbnail" src="https://borderzine.test/wp-content/uploads/2019/09/2019-la-square-140x140.jpg" alt="" width="140" height="140" /></p>
        <p>Lorem Ipsum Dolor Sit Amet. Laudantium accusamus ut exercitationem qui molestiae a modi maiores. Consequatur aliquam est fugit voluptatem porro. Voluptatem cupiditate eligendi est. A in ut quia recusandae inventore est veniam ducimus. Impedit ducimus totam qui doloribus quis tenetur est harum.</p>
        <p>Our Border Life is made up of "Our Stories" and "Our Voices". Scroll below to see each section.</p>
        ```
    - Layout: no regions
    - Footer Layout Style: Use Widget
4. In the widget area created for the footer widget area, put widgets that you'd like to see at full width.