### PR TITLE
Remove author email from author-bio-social-links partial

### DIFF
--- a/wp-content/themes/borderzine/partials/author-bio-social-links.php
+++ b/wp-content/themes/borderzine/partials/author-bio-social-links.php
@@ -12,13 +12,6 @@ $email = $author_obj->user_email;
  */
 $user_meta = get_user_meta($author_obj->ID);
 
-$show_email = 'off';
-if (isset($user_meta['show_email'][0])) {
-	$show_email = $user_meta['show_email'][0];
-} else if ( !empty($author_obj->show_email) ) {
-	$show_email = $author_obj->show_email;
-}
-
 ?>
 <ul class="social-links">
 	<?php if ( $fb = $author_obj->fb ) { ?>
@@ -30,12 +23,6 @@ if (isset($user_meta['show_email'][0])) {
 	<?php if ( $twitter = $author_obj->twitter ) { ?>
 		<li class="twitter">
 			<a href="https://twitter.com/<?php echo largo_twitter_url_to_username ( $twitter ); ?>"><i class="icon-twitter"></i></a>
-		</li>
-	<?php } ?>
-
-	<?php if ( $email && $show_email !== 'off' ) { ?>
-		<li class="email">
-			<a class="email" href="mailto:<?php echo esc_attr( $email ); ?>" title="e-mail <?php echo esc_attr( $author_obj->display_name ); ?>"><i class="icon-mail"></i></a>
 		</li>
 	<?php } ?>
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the author email link from the `author-bio-social-links.php` partial template

Article before:
![Screen Shot 2019-10-01 at 3 50 10 PM](https://user-images.githubusercontent.com/18353636/65995346-57f3c700-e463-11e9-85f8-a950661244eb.png)

Article after:
![Screen Shot 2019-10-01 at 3 50 22 PM](https://user-images.githubusercontent.com/18353636/65995345-57f3c700-e463-11e9-9c99-7462b9000856.png)

Author page before:
![Screen Shot 2019-10-01 at 3 49 57 PM](https://user-images.githubusercontent.com/18353636/65995347-57f3c700-e463-11e9-9aea-66a5e326e377.png)

Author page after:
![Screen Shot 2019-10-01 at 3 50 26 PM](https://user-images.githubusercontent.com/18353636/65995344-575b3080-e463-11e9-92df-0c525cd1a4ce.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #61 

## Testing/Questions

Features that this PR affects:

- Author bios

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?